### PR TITLE
sass-embedded (1.62.1-arm64-darwin)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
     rouge (4.1.3)
     ruby2_keywords (0.0.5)
     safe_yaml (1.0.5)
-    sass-embedded (1.64.2-arm64-darwin)
+    sass-embedded (1.62.1-arm64-darwin)
       google-protobuf (~> 3.23)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)


### PR DESCRIPTION
In [Gemfile.lock](./Gemfile.lock) do not upgrade `sass-embedded (1.62.1-arm64-darwin)` as long as [envygeeks/jekyll-docker](https://github.com/envygeeks/jekyll-docker) has not updated `base_image` to `ruby:3.1.1-alpine3.18`.

# Pull Request Check List

Resolves: #issue-number-here

<!-- 

This is just a reminder about the most common mistakes.
Please make sure that you tick all *appropriate* boxes.
But please read our [contribution guide](../CONTRIBUTING.md) at least once, it will save you unnecessary review cycles!

-->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- 

If you have *any* questions to *any* of the points above, just **submit and ask**! 
This checklist is here to *help* you, not to deter you from contributing!

-->
